### PR TITLE
Fix code scanning alert no. 20: Cross-site scripting

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,11 @@
 	</properties>
 
 	<dependencies>
+	<dependency>
+	<groupId>org.apache.commons</groupId>
+	<artifactId>commons-text</artifactId>
+	<version>1.12.0</version>
+	</dependency>
 		<dependency>
 			<groupId>com.onelogin</groupId>
 			<artifactId>java-saml</artifactId>

--- a/src/main/java/servlets/module/challenge/XssChallengeSix.java
+++ b/src/main/java/servlets/module/challenge/XssChallengeSix.java
@@ -1,6 +1,7 @@
 package servlets.module.challenge;
 
 import dbProcs.Getter;
+import org.apache.commons.text.StringEscapeUtils;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.Locale;
@@ -80,7 +81,8 @@ public class XssChallengeSix extends HttpServlet {
           String searchTerm = request.getParameter("searchTerm");
           log.debug("User Submitted - " + searchTerm);
           searchTerm = XssFilter.anotherBadUrlValidate(searchTerm);
-          userPost = "<a href=\"" + searchTerm + "\">Your HTTP Link!</a>";
+          String encodedSearchTerm = StringEscapeUtils.escapeHtml4(searchTerm);
+          userPost = "<a href=\"" + encodedSearchTerm + "\">Your HTTP Link!</a>";
           log.debug("After Sanitising - " + searchTerm);
 
           boolean xssDetected = FindXSS.search(userPost);


### PR DESCRIPTION
Fixes [https://github.com/Maneppagolmanju/SixtSecurityShepherd/security/code-scanning/20](https://github.com/Maneppagolmanju/SixtSecurityShepherd/security/code-scanning/20)

To fix the cross-site scripting vulnerability, we need to ensure that the user input (`searchTerm`) is properly sanitized and encoded before being included in the HTML response. The best way to achieve this is by using a library that provides contextual output encoding for HTML.

We will use the `StringEscapeUtils` class from the Apache Commons Text library to encode the `searchTerm` before including it in the HTML response. This will ensure that any potentially dangerous characters in the user input are properly escaped.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
